### PR TITLE
Fixed issue #2 by making the switch statement condition in Program.cs…

### DIFF
--- a/Restaurant.ConsoleApp/Program.cs
+++ b/Restaurant.ConsoleApp/Program.cs
@@ -107,17 +107,17 @@ namespace Restaurant.ConsoleApp
             while (quitFlag == false)
                 {
                 Menu.CustMenu(s_Stores, customer);
-                var loggedInOptions = Convert.ToInt32(Console.ReadLine());
+                var loggedInOptions = Console.ReadLine();
 
-                switch (loggedInOptions)
+                switch (loggedInOptions) // strings of numbers (to avoid exceptions when converting to switch statement condition")
                 {
-                    case 1:
+                    case "1":
                         //login
                         Console.WriteLine("Place an order");
                         AddOrder(customer, store);
 
                         break;
-                    case 2:
+                    case "2":
                         //register
                         Console.WriteLine("Showing your order history");
                         ShowOrderHistory(customer);


### PR DESCRIPTION
… into a string rather than an int that has to be converted to. Less bugs from converting/less exceptions

What would happen is that an exception was thrown if user typed strings (like a)

Now there cannot be exceptions from trying to convert "a" to a number just for the condition of the switch statement